### PR TITLE
Fix pd Series related issues, seemingly due to pd and/or python version

### DIFF
--- a/mittens/np_mittens.py
+++ b/mittens/np_mittens.py
@@ -118,9 +118,9 @@ class Mittens(MittensBase):
         weighted_diffs = np.multiply(weights, diffs)
         wgrad = weighted_diffs.dot(self.C)
         cgrad = weighted_diffs.T.dot(self.W)
-        bwgrad = weighted_diffs.sum(axis=1).reshape(-1, 1)
-        bcgrad = weighted_diffs.sum(axis=0).reshape(-1, 1)
-        error = (0.5 * np.multiply(weights, diffs ** 2)).sum()
+        bwgrad = weighted_diffs.sum(axis=1).values.reshape(-1, 1)
+        bcgrad = weighted_diffs.sum(axis=0).values.reshape(-1, 1)
+        error = (0.5 * np.multiply(weights.values, diffs.values ** 2)).sum()
 
         # Then we add the Mittens term (only if mittens > 0)
         if self.mittens > 0:


### PR DESCRIPTION
While running the code in page 74 of [cs224u vsm slide](http://web.stanford.edu/class/cs224u/materials/cs224u-2020-vsm-handout.pdf), I saw the issues described below.

I am not sure if this is due to the behaviors of python and pandas over time or my environment. So feel free to ignore if this is not related.

After this change, similar losses  as in the slide are obtained.
![Screen Shot 2020-09-06 at 01 54 34](https://user-images.githubusercontent.com/1240382/92322083-fc6f7900-efe3-11ea-8a0d-395cffca3ec4.png)


On a related code on the page 74 of the same slide `glv.sess.close()` seems to be obsolete code.

- Fix for 'AttributeError: 'Series' object has no attribute 'reshape'
Use values before reashape as suggested the following link
https://stackoverflow.com/questions/53723928/attributeerror-series-object-has-no-attribute-reshape
- use numpy ndarray to sum, otherwise pd sum's generates non sclar
  errors

- running environment, used the [conda configuration](https://nbviewer.jupyter.org/github/cgpotts/cs224u/blob/master/setup.ipynb), here are 

```
on Mac
numpy==1.19.1
pandas==1.1.0
python==3.7.7

```